### PR TITLE
refactor: renamed ErrInvalidAction to NewErrInvalidAction

### DIFF
--- a/pongo/errors.go
+++ b/pongo/errors.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 )
 
-var ErrNoSchemaTypeSet = fmt.Errorf("this SchemaNode has no valid SchemaType set")
+var ErrNoSchemaTypeSet = errors.New("this SchemaNode has no valid SchemaType set")
 var ErrSchemaNotJSONSchemaMarshalable = errors.New("this SchemaType is not JSONSchema marshalable")
+var ErrInvalidAction = errors.New("cannot execute schema action")
 
-func ErrInvalidAction(schemaType SchemaType, action SchemaAction) error {
-	return fmt.Errorf("cannot execute schema action %s on schema type %s", action, reflect.TypeOf(schemaType).Name())
+func NewErrInvalidAction(schemaType SchemaType, action SchemaAction) error {
+	return fmt.Errorf("%w %s on schema type %s", ErrInvalidAction, action, reflect.TypeOf(schemaType).Name())
 }
 
 type SchemaError struct {

--- a/pongo/type_bool.go
+++ b/pongo/type_bool.go
@@ -54,7 +54,7 @@ func (b BoolType) Process(action SchemaAction, data *DataPointer) (Data, error) 
 		return parsedBool, nil
 	}
 
-	return nil, NewSchemaErrorWithError(data.Path(), ErrInvalidAction(b, action))
+	return nil, NewSchemaErrorWithError(data.Path(), NewErrInvalidAction(b, action))
 }
 
 func (b *BoolType) SetCast(cast bool) *BoolType {
@@ -78,7 +78,7 @@ func (b *BoolType) SchemaTypeID() string {
 
 func (b BoolType) MarshalJSONSchema(action SchemaAction) ([]byte, error) {
 	if action != SchemaActionParse && action != SchemaActionSerialize {
-		return nil, ErrInvalidAction(b, action)
+		return nil, NewErrInvalidAction(b, action)
 	}
 
 	var jsonObject = map[string]interface{}{"type": "boolean"}

--- a/pongo/type_bytes.go
+++ b/pongo/type_bytes.go
@@ -55,7 +55,7 @@ func (b BytesType) Process(action SchemaAction, dataPointer *DataPointer) (data 
 		return bytes, nil
 	}
 
-	return nil, ErrInvalidAction(b, action)
+	return nil, NewErrInvalidAction(b, action)
 }
 
 func (b BytesType) SetMinLen(i int) *BytesType {
@@ -89,7 +89,7 @@ func (b *BytesType) SchemaTypeID() string {
 
 func (b BytesType) MarshalJSONSchema(action SchemaAction) ([]byte, error) {
 	if action != SchemaActionParse {
-		return nil, ErrInvalidAction(b, action)
+		return nil, NewErrInvalidAction(b, action)
 	}
 
 	return json.Marshal(map[string]interface{}{

--- a/pongo/type_datetime.go
+++ b/pongo/type_datetime.go
@@ -65,7 +65,7 @@ func (d DatetimeType) Process(action SchemaAction, dataPointer *DataPointer) (da
 		return t, nil
 	}
 
-	return nil, NewSchemaErrorWithError(dataPointer.Path(), ErrInvalidAction(d, action))
+	return nil, NewSchemaErrorWithError(dataPointer.Path(), NewErrInvalidAction(d, action))
 }
 
 func (d *DatetimeType) SetFormat(f string) *DatetimeType {
@@ -122,7 +122,7 @@ func (d DatetimeType) MarshalJSONSchema(action SchemaAction) ([]byte, error) {
 	}
 
 	if action != SchemaActionParse {
-		return nil, ErrInvalidAction(d, action)
+		return nil, NewErrInvalidAction(d, action)
 	}
 
 	return json.Marshal(map[string]interface{}{

--- a/pongo/type_float64.go
+++ b/pongo/type_float64.go
@@ -41,7 +41,7 @@ func (f64 Float64Type) Process(action SchemaAction, dataPointer *DataPointer) (d
 	var n float64
 
 	if action != SchemaActionParse && action != SchemaActionSerialize {
-		return nil, ErrInvalidAction(f64, action)
+		return nil, NewErrInvalidAction(f64, action)
 	}
 
 	if !f64.Cast.GetAction(action) {
@@ -99,7 +99,7 @@ func (f64 *Float64Type) SchemaTypeID() string {
 
 func (f64 Float64Type) MarshalJSONSchema(action SchemaAction) ([]byte, error) {
 	if action != SchemaActionParse && action != SchemaActionSerialize {
-		return nil, ErrInvalidAction(f64, action)
+		return nil, NewErrInvalidAction(f64, action)
 	}
 
 	var jsonObject = map[string]interface{}{"type": "number"}

--- a/pongo/type_int.go
+++ b/pongo/type_int.go
@@ -47,7 +47,7 @@ func (i IntType) Process(action SchemaAction, dataPointer *DataPointer) (data Da
 	var n int
 
 	if action != SchemaActionParse && action != SchemaActionSerialize {
-		return nil, ErrInvalidAction(i, action)
+		return nil, NewErrInvalidAction(i, action)
 	}
 
 	if !i.Cast.GetAction(action) {
@@ -104,7 +104,7 @@ func (i *IntType) SchemaTypeID() string {
 
 func (i IntType) MarshalJSONSchema(action SchemaAction) ([]byte, error) {
 	if action != SchemaActionParse && action != SchemaActionSerialize {
-		return nil, ErrInvalidAction(i, action)
+		return nil, NewErrInvalidAction(i, action)
 	}
 
 	var jsonObject = map[string]interface{}{"type": "number"}

--- a/pongo/type_string.go
+++ b/pongo/type_string.go
@@ -85,7 +85,7 @@ func (s *StringType) SchemaTypeID() string {
 
 func (s StringType) MarshalJSONSchema(action SchemaAction) ([]byte, error) {
 	if action != SchemaActionParse && action != SchemaActionSerialize {
-		return nil, ErrInvalidAction(s, action)
+		return nil, NewErrInvalidAction(s, action)
 	}
 
 	var jsonObject = map[string]interface{}{"type": "string"}


### PR DESCRIPTION
## This PR
proposes the following changes
* `ErrInvalidAction` now is an error that can be compared with `errors.Is`
  * this is valid also for errors created with `NewErrInvalidAction`