### PR TITLE
Refactor/path from `SchemaType` to `SchemaNode`

### DIFF
--- a/pongo/data.go
+++ b/pongo/data.go
@@ -19,13 +19,13 @@ type DataPointer struct {
 }
 
 // NewDataPointer construct a DataPointer
-func NewDataPointer(data Data, schemaNode *SchemaNode) *DataPointer {
+func NewDataPointer(schemaNode *SchemaNode, data Data) *DataPointer {
 	dp := &DataPointer{
 		root: data,
 	}
 
 	if data != nil {
-		dp.path = *NewPath(*NewPathElement("", data, schemaNode))
+		dp.path = *NewPath(*NewPathElement(schemaNode, data, ""))
 	} else {
 		dp.path = *NewPath()
 	}
@@ -34,8 +34,8 @@ func NewDataPointer(data Data, schemaNode *SchemaNode) *DataPointer {
 }
 
 // Push a new entry in the DataPointer Path stack
-func (d DataPointer) Push(key string, data Data, schemaNode *SchemaNode) *DataPointer {
-	d.path = *d.path.Push(key, data, schemaNode)
+func (d DataPointer) Push(schemaNode *SchemaNode, data Data, key string) *DataPointer {
+	d.path = *d.path.Push(schemaNode, data, key)
 	return &d
 }
 

--- a/pongo/data.go
+++ b/pongo/data.go
@@ -19,13 +19,13 @@ type DataPointer struct {
 }
 
 // NewDataPointer construct a DataPointer
-func NewDataPointer(data Data, schemaType SchemaType) *DataPointer {
+func NewDataPointer(data Data, schemaNode *SchemaNode) *DataPointer {
 	dp := &DataPointer{
 		root: data,
 	}
 
 	if data != nil {
-		dp.path = *NewPath(*NewPathElement("", data, schemaType))
+		dp.path = *NewPath(*NewPathElement("", data, schemaNode))
 	} else {
 		dp.path = *NewPath()
 	}
@@ -34,8 +34,8 @@ func NewDataPointer(data Data, schemaType SchemaType) *DataPointer {
 }
 
 // Push a new entry in the DataPointer Path stack
-func (d DataPointer) Push(key string, data Data, schemaType SchemaType) *DataPointer {
-	d.path = *d.path.Push(key, data, schemaType)
+func (d DataPointer) Push(key string, data Data, schemaNode *SchemaNode) *DataPointer {
+	d.path = *d.path.Push(key, data, schemaNode)
 	return &d
 }
 

--- a/pongo/path.go
+++ b/pongo/path.go
@@ -19,7 +19,7 @@ type PathElement struct {
 }
 
 // NewPathElement is a constructor for PathElement
-func NewPathElement(key string, data Data, schemaNode *SchemaNode) *PathElement {
+func NewPathElement(schemaNode *SchemaNode, data Data, key string) *PathElement {
 	return &PathElement{
 		key:         key,
 		data:        data,
@@ -37,7 +37,7 @@ func (e PathElement) Data() Data {
 	return e.data
 }
 
-func (e PathElement) Schema() SchemaType {
+func (e PathElement) SchemaNode() *SchemaNode {
 	return e.schemaNode
 }
 
@@ -140,8 +140,8 @@ func (path Path) Last() *PathElement {
 }
 
 // Push a new PathElement in Path
-func (path Path) Push(key string, data Data, schemaNode *SchemaNode) *Path {
-	path.elements = append(path.elements, *NewPathElement(key, data, schemaNode))
+func (path Path) Push(schemaNode *SchemaNode, data Data, key string) *Path {
+	path.elements = append(path.elements, *NewPathElement(schemaNode, data, key))
 
 	return &path
 }

--- a/pongo/path.go
+++ b/pongo/path.go
@@ -15,17 +15,17 @@ type PathElement struct {
 	data        Data
 	override    Data
 	hasOverride bool
-	schemaType  SchemaType
+	schemaNode  *SchemaNode
 }
 
 // NewPathElement is a constructor for PathElement
-func NewPathElement(key string, data Data, schemaType SchemaType) *PathElement {
+func NewPathElement(key string, data Data, schemaNode *SchemaNode) *PathElement {
 	return &PathElement{
 		key:         key,
 		data:        data,
 		override:    nil,
 		hasOverride: false,
-		schemaType:  schemaType,
+		schemaNode:  schemaNode,
 	}
 }
 
@@ -38,7 +38,7 @@ func (e PathElement) Data() Data {
 }
 
 func (e PathElement) Schema() SchemaType {
-	return e.schemaType
+	return e.schemaNode
 }
 
 func (e *PathElement) SetOverride(override Data) {
@@ -75,7 +75,7 @@ func (path Path) String() string {
 	var stringPath = ""
 
 	for _, pathElement := range path.elements {
-		schemaTypeID := SchemaTypeID(pathElement.schemaType)
+		schemaTypeID := SchemaTypeID(pathElement.schemaNode)
 		stringPath += fmt.Sprintf("%s%s<%s>", PathSeparator, pathElement.key, schemaTypeID)
 	}
 
@@ -140,8 +140,8 @@ func (path Path) Last() *PathElement {
 }
 
 // Push a new PathElement in Path
-func (path Path) Push(key string, data Data, schemaType SchemaType) *Path {
-	path.elements = append(path.elements, *NewPathElement(key, data, schemaType))
+func (path Path) Push(key string, data Data, schemaNode *SchemaNode) *Path {
+	path.elements = append(path.elements, *NewPathElement(key, data, schemaNode))
 
 	return &path
 }

--- a/pongo/schema.go
+++ b/pongo/schema.go
@@ -295,5 +295,5 @@ func Process(schema SchemaType, action SchemaAction, data Data) (Data, error) {
 	if !ok {
 		schemaNode = Schema(schema)
 	}
-	return schema.Process(action, NewDataPointer(data, schemaNode))
+	return schema.Process(action, NewDataPointer(schemaNode, data))
 }

--- a/pongo/schema.go
+++ b/pongo/schema.go
@@ -259,6 +259,9 @@ func SchemaTypeID(s SchemaType) string {
 	// we must remove the first char of type, which is always a `*`
 	// since SchemaType is an interface
 
+	if schemaNode, ok := s.(*SchemaNode); ok {
+		return SchemaTypeID(schemaNode.Type())
+	}
 	if customSchemaTypeID, ok := s.(CustomSchemaTypeID); ok {
 		return customSchemaTypeID.SchemaTypeID()
 	}
@@ -288,5 +291,9 @@ func Serialize(schema SchemaType, data Data) (Data, error) {
 // Process is wrapper for SchemaNode.Process that automatically
 // transforms Data into a DataPointer
 func Process(schema SchemaType, action SchemaAction, data Data) (Data, error) {
-	return schema.Process(action, NewDataPointer(data, schema))
+	schemaNode, ok := schema.(*SchemaNode)
+	if !ok {
+		schemaNode = Schema(schema)
+	}
+	return schema.Process(action, NewDataPointer(data, schemaNode))
 }

--- a/pongo/type_list.go
+++ b/pongo/type_list.go
@@ -43,7 +43,7 @@ func (l ListType) Process(action SchemaAction, dataPointer *DataPointer) (data D
 	var processedSlice = []interface{}{}
 
 	for key := range d {
-		ptr := dataPointer.Push(fmt.Sprintf("[%d]", key), d[key], l.Type)
+		ptr := dataPointer.Push(l.Type, d[key], fmt.Sprintf("[%d]", key))
 		var item interface{}
 
 		switch action {

--- a/pongo/type_list.go
+++ b/pongo/type_list.go
@@ -43,7 +43,7 @@ func (l ListType) Process(action SchemaAction, dataPointer *DataPointer) (data D
 	var processedSlice = []interface{}{}
 
 	for key := range d {
-		ptr := dataPointer.Push(fmt.Sprintf("[%d]", key), d[key], &l)
+		ptr := dataPointer.Push(fmt.Sprintf("[%d]", key), d[key], l.Type)
 		var item interface{}
 
 		switch action {

--- a/pongo/type_object.go
+++ b/pongo/type_object.go
@@ -41,20 +41,20 @@ func (o ObjectType) Process(action SchemaAction, dataPointer *DataPointer) (data
 	var processedObject = map[string]interface{}{}
 	for key := range d {
 		// load BaseSchemaType, run all pre-checks related to ObjectType
-		validator, ok := o.SchemaMap[key]
+		schemaNode, ok := o.SchemaMap[key]
 		if !ok {
 			schemaError = schemaError.Append(dataPointer.Path(), fmt.Errorf("cannot validate data as ObjectType at %s, cannot get key %s", dataPointer.Path(), key))
 			continue
 		}
 
 		// navigate the DataPointer
-		ptr := dataPointer.Push(key, d[key], &o)
+		ptr := dataPointer.Push(key, d[key], schemaNode)
 
 		switch action {
 		case SchemaActionSerialize:
-			processedObject[key], err = validator.Serialize(ptr)
+			processedObject[key], err = schemaNode.Serialize(ptr)
 		case SchemaActionParse:
-			processedObject[key], err = validator.Parse(ptr)
+			processedObject[key], err = schemaNode.Parse(ptr)
 		}
 
 		if err != nil {

--- a/pongo/type_object.go
+++ b/pongo/type_object.go
@@ -48,7 +48,7 @@ func (o ObjectType) Process(action SchemaAction, dataPointer *DataPointer) (data
 		}
 
 		// navigate the DataPointer
-		ptr := dataPointer.Push(key, d[key], schemaNode)
+		ptr := dataPointer.Push(schemaNode, d[key], key)
 
 		switch action {
 		case SchemaActionSerialize:

--- a/tests/assets_test.go
+++ b/tests/assets_test.go
@@ -270,7 +270,7 @@ func (t testSchemaMarshall) Validate() error {
 			return err
 		}
 
-		_, schemaErr := pongoSchema.Parse(pongo.NewDataPointer(d, pongoSchema))
+		_, schemaErr := pongoSchema.Parse(pongo.NewDataPointer(pongoSchema, d))
 		if schemaErr != nil {
 			return fmt.Errorf("cannot validate Pongo schema for ok test %s/%s: %w", t.dir, okFile, schemaErr)
 		}
@@ -295,7 +295,7 @@ func (t testSchemaMarshall) Validate() error {
 			return err
 		}
 
-		_, schemaErr := pongoSchema.Parse(pongo.NewDataPointer(d, pongoSchema))
+		_, schemaErr := pongoSchema.Parse(pongo.NewDataPointer(pongoSchema, d))
 		if schemaErr == nil {
 			return fmt.Errorf("cannot validate Pongo schema for ko test %s/%s: expected error, got no one", t.dir, koFile)
 		}

--- a/tests/data_test.go
+++ b/tests/data_test.go
@@ -16,8 +16,8 @@ func TestData(t *testing.T) {
 	}
 
 	s := pongo.String()
-	d = pongo.NewDataPointer(TestValue1, pongo.Schema(s))
-	d = d.Push("1", TestValue2, pongo.Schema(s))
+	d = pongo.NewDataPointer(pongo.Schema(s), TestValue1)
+	d = d.Push(pongo.Schema(s), TestValue2, "1")
 
 	path := d.Path()
 	if v := path.Size(); v != 2 {
@@ -63,8 +63,8 @@ func TestData(t *testing.T) {
 	}
 
 	// testing variable override
-	d = d.Push("foo", "bar", pongo.Schema(pongo.String()))
-	d2 := d.Push("foo", "baz", pongo.Schema(pongo.String()))
+	d = d.Push(pongo.Schema(pongo.String()), "bar", "foo")
+	d2 := d.Push(pongo.Schema(pongo.String()), "baz", "foo")
 	if v := d2.Get(); v != "baz" {
 		t.Errorf("expected value baz, got: %v", v)
 	}

--- a/tests/data_test.go
+++ b/tests/data_test.go
@@ -16,8 +16,8 @@ func TestData(t *testing.T) {
 	}
 
 	s := pongo.String()
-	d = pongo.NewDataPointer(TestValue1, s)
-	d = d.Push("1", TestValue2, s)
+	d = pongo.NewDataPointer(TestValue1, pongo.Schema(s))
+	d = d.Push("1", TestValue2, pongo.Schema(s))
 
 	path := d.Path()
 	if v := path.Size(); v != 2 {
@@ -63,8 +63,8 @@ func TestData(t *testing.T) {
 	}
 
 	// testing variable override
-	d = d.Push("foo", "bar", pongo.String())
-	d2 := d.Push("foo", "baz", pongo.String())
+	d = d.Push("foo", "bar", pongo.Schema(pongo.String()))
+	d2 := d.Push("foo", "baz", pongo.Schema(pongo.String()))
 	if v := d2.Get(); v != "baz" {
 		t.Errorf("expected value baz, got: %v", v)
 	}


### PR DESCRIPTION
## This PR

proposes the following changes:
* `PathElement` now use only `SchemaNode` instead of `SchemaType`
* `DataPointer` Path is pushed forward
  * which means if SchemaType a need to push to SchemaNode b, the new Data are pushed with SchemaNode b